### PR TITLE
Fix mysql config permissions for Windows users

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -14,6 +14,8 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=dc-dev
+    command: |
+      bash -c "chmod 644 /etc/mysql/conf.d/pageonex-build.cnf && /entrypoint.sh mysqld"
 
   app_build:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=dc-prod
+    command: |
+      bash -c "chmod 644 /etc/mysql/conf.d/pageonex.cnf && /entrypoint.sh mysqld"
 
   app:
     image: pageonex/pageonex:latest


### PR DESCRIPTION
Windows docker mounts are in world writable mode, which makes mysql
ignore our port configuration. This patch solves it in a brutal way, by
manually setting the permissions of the file rather than playing with
docker mount syntaxes that may or may not work depending on the FS
driver.

Fixes #240

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>